### PR TITLE
Adding command line tool to look up errorno's

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,25 @@ fs.readFile('thisisnotarealfile.txt', function (err, data) {
 })
 ```
 
+Use the command line tool
+
+    ~ $ errno 53
+    {
+      "errno": 53,
+      "code": "ENOTEMPTY",
+      "description": "directory not empty"
+    }
+    ~ $ errno EROFS
+    {
+      "errno": 56,
+      "code": "EROFS",
+      "description": "read-only file system"
+    }
+    ~ $ errno unknown
+    undefined
+
+Supply no arguments for the full list
+
 *Copyright (c) 2012 [Rod Vagg](https://github.com/rvagg) ([@rvagg](https://twitter.com/rvagg))*
 
 Made available under the MIT licence:

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+var errno = require('./')
+  , data
+  , code
+
+if (process.argv[2] === undefined)
+  return console.log(JSON.stringify(errno.code, null, 2))
+
+if (code = +process.argv[2])
+  data = errno.errno[code]
+else
+  data = errno.code[process.argv[2]]
+console.log(JSON.stringify(data, null, 2))

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   , "version": "0.0.2"
   , "main": "errno.js"
   , "dependencies": {}
+  , "bin": {
+      "errno": "./cli.js"
+    }
   , "devDependencies": {
         "request": "*"
     }


### PR DESCRIPTION
this is so much better than `grep /usr/include/sys/errno.h EAGAIN`

```
~ $ errno 53
{
  "errno": 53,
  "code": "ENOTEMPTY",
  "description": "directory not empty"
}
~ $ errno EROFS
{
  "errno": 56,
  "code": "EROFS",
  "description": "read-only file system"
}
~ $ errno unknown
undefined
```
