### PR TITLE
Support enforced strict mode

### DIFF
--- a/custom.js
+++ b/custom.js
@@ -1,5 +1,7 @@
 var prr = require('prr')
 
+var isStrictMode = (function () { return !this; } )()
+
 function init (type, message, cause) {
   prr(this, {
       type    : type
@@ -15,7 +17,7 @@ function init (type, message, cause) {
 function CustomError (message, cause) {
   Error.call(this)
   if (Error.captureStackTrace)
-    Error.captureStackTrace(this, arguments.callee)
+    Error.captureStackTrace(this, isStrictMode ? undefined : arguments.callee)
   init.call(this, 'CustomError', message, cause)
 }
 
@@ -37,7 +39,7 @@ function createError (errno, type, proto) {
     }
     Error.call(this)
     if (Error.captureStackTrace)
-      Error.captureStackTrace(this, arguments.callee)
+      Error.captureStackTrace(this, isStrictMode ? undefined : arguments.callee)
   }
   err.prototype = !!proto ? new proto() : new CustomError()
   return err


### PR DESCRIPTION
All (>50) modules that I use work fine with enforced strict mode.
The only exception is `errno`. This commit fixes that.

Steps to reproduce:

```
mkdir /tmp/a
cd /tmp/a
npm install errno
echo 'require("errno")' > w.js
node --use_strict w.js
```

```
/tmp/a/node_modules/errno/custom.js:18
    Error.captureStackTrace(this, arguments.callee)
                                           ^

TypeError: 'caller', 'callee', and 'arguments' properties may not be accessed on strict mode functions or the arguments objects for calls to them
    at Error.CustomError (/tmp/a/node_modules/errno/custom.js:18:44)
    at createError (/tmp/a/node_modules/errno/custom.js:42:43)
    at ce (/tmp/a/node_modules/errno/custom.js:48:12)
    at module.exports (/tmp/a/node_modules/errno/custom.js:52:25)
    at Object.<anonymous> (/tmp/a/node_modules/errno/errno.js:312:44)
    at Module._compile (module.js:425:26)
    at Object.Module._extensions..js (module.js:432:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:313:12)
    at Module.require (module.js:366:17)
```
