### PR TITLE
Use error name if there is no message

### DIFF
--- a/custom.js
+++ b/custom.js
@@ -1,12 +1,18 @@
 var prr = require('prr')
 
 function init (type, message, cause) {
+  if (!!message && typeof message != 'string') {
+   if (message.message)
+     message = message.message
+   else
+     message = message.name
+  }
   prr(this, {
       type    : type
     , name    : type
       // can be passed just a 'cause'
     , cause   : typeof message != 'string' ? message : cause
-    , message : !!message && typeof message != 'string' ? message.message : message
+    , message : message
 
   }, 'ewr')
 }

--- a/test.js
+++ b/test.js
@@ -71,3 +71,17 @@ test('callstack', function (t) {
     secondLastFunction(MyError3, testFrames(t))
   })
 })
+
+test('error without message', function (t) {
+  const Cust = errno.create('WriteError')
+  const cust = new Cust({
+      code: 22
+    , message: ''
+    , name: 'QuotaExceededError'})
+
+  t.equal(cust.name, 'WriteError', 'correct custom name')
+  t.equal(cust.type, 'WriteError', 'correct custom type')
+  t.equal(cust.message, 'QuotaExceededError', 'message is the name')
+  t.notOk(cust.cause, 'no cause')
+  t.end()
+})


### PR DESCRIPTION
There are errors (like `QuotaExceededError`) that don't contain
a message. If that's the case, use their name instead.