### PR TITLE
Add power support ppc64le and update versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,17 @@ sudo: false
 language: node_js
 
 node_js:
+  - 14
+  - 12
+  - 10
   - 9
   - 8
   - 7
   - 6
   - 5
   - 4
+
+arch:
+  - amd64
+  - ppc64le
+  


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.